### PR TITLE
more than 4000 devices are incompatible with this plugin because of this requirement

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,7 +53,7 @@
             <uses-permission android:name="android.permission.INTERNET" /> 
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" /> 
             <uses-permission android:name="android.permission.BLUETOOTH" /> 
-            <uses-feature android:name="android.hardware.usb.host" /> 
+            <uses-feature android:name="android.hardware.usb.host" android:required="false" /> 
             <uses-permission android:name="android.hardware.usb.accessory" /> 
             <uses-permission android:name="android.permission.DEVICE_POWER"/>
             <uses-permission android:name="android.permission.WAKE_LOCK"/> 

--- a/src/android/MKBluetoothPrinter.java
+++ b/src/android/MKBluetoothPrinter.java
@@ -827,7 +827,7 @@ public class MKBluetoothPrinter extends CordovaPlugin {
         p.setTextSize(33);
         canvas.drawBitmap(src, 0, 0, p);
         canvas.drawText(mstrTitle, 20, 310, p);
-        canvas.save(Canvas.ALL_SAVE_FLAG);
+        canvas.save();
         canvas.restore();
         return bmpTemp;
     }


### PR DESCRIPTION
I don't no why this android.hardware.usb.host feature is present and required on this plugin, but turning it optional will help a lot.
There is no problem if the plugin doesn't work without this feature, but users could still download your app and use the other features the app.
Thanks for this awesome plugins guys, I hope this small fix can benefit others consumers of this plugins too.